### PR TITLE
fix(extract.js): fix xml translation issue

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -503,8 +503,7 @@ exports.Extractor = class Extractor {
 
     if (filename.endsWith('.xml')) {
       const textArray = [];
-      const elementAttributes = ['label', 'sublabel', 'label-short'];
-      elementAttributes.map((keyword) => {
+      this.options.xmlAttributes.map((keyword) => {
         if (node.attr(keyword) !== undefined) {
           const value = node.attr(keyword);
           if (!value.trim().startsWith('{{') && !value.trim().endsWith('}}')) {
@@ -522,7 +521,7 @@ exports.Extractor = class Extractor {
         }
       });
       const newArray = textArray.map((element) => {
-        return new exports.NodeTranslationInfo(node, element, reference, elementAttributes);
+        return new exports.NodeTranslationInfo(node, element, reference, this.options.xmlAttributes);
       });
       return newArray;
     }

--- a/src/extract.js
+++ b/src/extract.js
@@ -501,19 +501,24 @@ exports.Extractor = class Extractor {
     const reference = new exports.TranslationReference(filename, content, el.startIndex);
     const node = $(el);
 
-    if (this._hasTranslationToken(node)) {
-      if (filename.endsWith('.xml')) {
-        const textArray = [];
-        this.options.attributes.map((keyword) => {
-          if (node.attr(keyword) !== undefined) {
+    if (filename.endsWith('.xml')) {
+      const textArray = [];
+      const elementAttributes = ['label', 'sublabel', 'label-short'];
+      elementAttributes.map((keyword) => {
+        if (node.attr(keyword) !== undefined) {
+          const value = node.attr(keyword);
+          if (!value.trim().startsWith('{{') && !value.trim().endsWith('}}')) {
             textArray.push(node.attr(keyword));
           }
-        });
-        const newArray = textArray.map((element) => {
-          return new exports.NodeTranslationInfo(node, element, reference, this.options.attributes);
-        });
-        return newArray;
-      }
+        }
+      });
+      const newArray = textArray.map((element) => {
+        return new exports.NodeTranslationInfo(node, element, reference, elementAttributes);
+      });
+      return newArray;
+    }
+
+    if (this._hasTranslationToken(node)) {
       const text = this._getNodeHTML(node);
 
       if (text.length !== 0) {

--- a/src/extract.js
+++ b/src/extract.js
@@ -509,6 +509,15 @@ exports.Extractor = class Extractor {
           const value = node.attr(keyword);
           if (!value.trim().startsWith('{{') && !value.trim().endsWith('}}')) {
             textArray.push(node.attr(keyword));
+          } else if (value.trim().startsWith('{{') && value.trim().endsWith('}}')) {
+            const exp = new RegExp('(?<=\').+?(?=\')', 'g');
+            const matches = value.match(exp);
+            if (matches) {
+              matches.forEach(match => {
+                const finalMatch = match.replace(/\\/, '');
+                textArray.push(finalMatch);
+              });
+            }
           }
         }
       });


### PR DESCRIPTION
Don't extract strings from xml (dynamic values) which start with '{{' and end with '}}'